### PR TITLE
Sync while maintaining UID/GID for files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM debian
+FROM alpine:3.12
 
-RUN apt-get update -y
-RUN apt-get install openssh-client rsync inotify-tools -y
+RUN apk -U update
+RUN apk add --no-cache dumb-init openssh-client openssh-server rsync inotify-tools bind-tools bash
 
 ADD sync-dnsmasq.sh /sync-dnsmasq.sh
 ADD sync-pihole.sh /sync-pihole.sh
-ADD healthCheck.sh /healthCheck.sh
 ADD entryPoint.sh /entryPoint.sh
+ADD sshd_config /
+ADD healthCheck.sh /healthCheck.sh
 
-ENTRYPOINT ["/entryPoint.sh"]
+ENTRYPOINT ["dumb-init", "/entryPoint.sh"]
 
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD /healthCheck.sh

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ This is the `docker-compose.yml` for the sender/master Pi-Hole:
 pihole:
     image: pihole/pihole:latest
     volumes:
-        - /mnt/ext/pihole/etc-pihole:/mnt/etc-pihole
-        - /mnt/ext/pihole/etc-dnsmasq-d:/mnt/etc-dnsmasq.d
+        - /mnt/ext/pihole/etc-pihole:/etc/pihole
+        - /mnt/ext/pihole/etc-dnsmasq-d:/etc/dnsmasq.d
     rest of pihole config...
 
 pihole-sync-sender:
@@ -62,8 +62,8 @@ This is the `docker-compose.yml` for the receiver/secondary Pi-Hole:
 pihole:
     image: pihole/pihole:latest
     volumes:
-        - /mnt/ext/pihole/etc-pihole:/mnt/etc-pihole
-        - /mnt/ext/pihole/etc-dnsmasq-d:/mnt/etc-dnsmasq.d
+        - /mnt/ext/pihole/etc-pihole:/etc/pihole
+        - /mnt/ext/pihole/etc-dnsmasq-d:/etc/dnsmasq.d
     rest of pihole config...
 
 pihole-sync-receiver:

--- a/README.md
+++ b/README.md
@@ -77,21 +77,29 @@ pihole-sync-receiver:
 Volume | Function 
 --- | -------- 
 `/root` | This is the directory in which the SSH key file and the known hosts file will be stored, so it needs to be persistent.
-`/etc/ssh` | This is the directory in which the SSH server key files and the SSH daemon config will be stored, so it needs to be persistent. This directory is only necessary on the `receiver` node, you can omit it on the `sender` node.
-`/mnt/etc-pihole` | This is the `/etc/pihole/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/pihole/ in the Pihole Docker container. See the compose file for details. For sending purposes, it can be mounted as read-only. It should not be read-only on the receiver.
-`/mnt/etc-dnsmasq.d` | This is the `/etc/dnsmasq.d/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/dnsmasq.d/ in the Pihole Docker container. See the compose file for details. For sending purposes, it can be mounted as read-only. It should not be read-only on the receiver.
+**Required on both nodes.**
+`/etc/ssh` | This is the directory in which the SSH server key files and the SSH daemon config will be stored, so it needs to be persistent. 
+**Required on the `sender` node only.**
+`/mnt/etc-pihole` | This is the `/etc/pihole/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/pihole/ in the Pihole Docker container. See the compose file for details. 
+**Required on both nodes. Can be mounted read-only on the `sender` node.**
+`/mnt/etc-dnsmasq.d` | This is the `/etc/dnsmasq.d/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/dnsmasq.d/ in the Pihole Docker container. See the compose file for details.
+**Required on both nodes. Can be mounted read-only on the `sender` node.**
 
 ### Environment Variables
 Variable | Function
 --- | --------
-`NODE` | This is where you should define if the container is the `sender` or the `receiver`. **Required on both nodes.**
-`REM_HOST` | This is the IP address (or FQDN/Hostname) of the remote Pi that we're syncting to. **Required on the `sender` node only.**
-`REM_SSH_PORT` | This is the non-standard SSH port that should be exposed on the container. Default of 22222 is probably fine. However, if you change this on the `sender` node, be sure to change the exposed port forward on the `receiver` node. **Required on the `sender` node only.**
+`NODE` | This is where you should define if the container is the `sender` or the `receiver`.
+**Required on both nodes.**
+`REM_HOST` | This is the IP address (or FQDN/Hostname) of the remote Pi that we're syncting to.
+**Required on the `sender` node only.**
+`REM_SSH_PORT` | This is the non-standard SSH port that should be exposed on the container. Default of 22222 is probably fine. However, if you change this on the `sender` node, be sure to change the exposed port forward on the `receiver` node.
+**Required on the `sender` node only.**
 
 ### Ports
 Port | Function
 --- | --------
-`22222` | This is the port you want to expose for rsync/ssh. Your host is likely using 22 for SSH already, so it should be a non-standard port. The default of 22222 is probably fine. However, if you change this on the `receiver` node, be sure to change the `REM_SSH_PORT` on the `sender` node. **Required on the `receiver` node only.**
+`22222` | This is the port you want to expose for rsync/ssh. Your host is likely using 22 for SSH already, so it should be a non-standard port. The default of 22222 is probably fine. However, if you change this on the `receiver` node, be sure to change the `REM_SSH_PORT` on the `sender` node.
+**Required on the `receiver` node only.**
 
 ## Support Information
 - Shell access while the container is running: `docker exec -it pihole-sync /bin/bash`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ A Docker Container To Sync Two Piholes.
 ## Introduction
 A Pihole runs your entire network. If it goes down, your whole network goes down. If you have a family at home, they're going to be pretty annoyed that the wifi goes out everytime you want to do some maintainence. The only solution to this problem is to have a redundant pihole on your network, but you don't want to change your settings in two different places.
 
-This repo allows you to synchronize between two piholes where one is the master and one is the slave. I'll be adding support for more piholes in future. Just update one pihole and the rest automatically update. It supports the `/etc/pihole/` and `/etc/dnsmasq.d/` directories, excluding `/etc/pihole/pihole-FTL.db` and `/etc/dnsmasq.d/01-pihole.conf` respectively, as these need to be independently managed.
+This repo allows you to synchronize between two piholes where one is the master and one is the slave. I'll be adding support for more piholes in future. Just update one pihole and the rest automatically update. It supports the `/etc/pihole/` and `/etc/dnsmasq.d/` directories, excluding some directories which should be client-independent.
+
+It is based on Alpine 3.12 and utilizes `dumb-init`, `openssh`, `rsync`, `inotify-tools`, and `bash` for an image size of about 28 MB.
+
+Because Pi-Hole Docker utilizes a UID/GID of 0:0 and 999:999, this presents a unique problem for sending files over SSH, as the only user who can receive the files and maintain the proper UID/GID flags is root. However, having a docker container SSH in to the root user of another host is undesirable for a number of security related reasons.
+
+By utilizing a `sender` container node on one Pi and a `receiver` container node on the other Pi, we're able to solve the issue of securely opening a root user to SSH, by having the `sender` container node SSH into the `receiver` container node, rather than the host. If the container were to be infiltrated, the infiltrater would have access to root only in the receiver container, and its mounted volumes.
 
 ## Why Docker PiHole Sync
 
@@ -22,41 +28,70 @@ Not only are your lists transferred, but all your other settings are transferred
 Unlike [pihole-cloudsync](https://github.com/stevejenkins/pihole-cloudsync), we don't require a repository to sync to. This means that your Piholes don't have to connect to the internet, and you don't have a large number of commits going into a dummy repository. This is especially nice if you show private contributions on your profile and don't want a huge number of changes being published to your Github profile
 
 #### NOTE: 
-The master Pihole must be able to SSH into the slave Pihole. If that's a restriction (maybe your Piholes are behind different VPNs), use [pihole-cloudsync](https://github.com/stevejenkins/pihole-cloudsync). 
+The 'sender' Pihole must be able to SSH into the 'receiver' Pihole. If that's a restriction (maybe your Piholes are behind different VPNs), use [pihole-cloudsync](https://github.com/stevejenkins/pihole-cloudsync). 
 
 ## Setup
 ### docker-compose.yml
-```
+
+This is the `docker-compose.yml` for the sender/master Pi-Hole:
+
+```yaml
 pihole:
     image: pihole/pihole:latest
     volumes:
-        - /mnt/ext/pihole/etc-pihole:/etc/pihole/
-		- /mnt/ext/pihole/etc-dnsmasq.d:/etc/dnsmasq.d/
+        - /mnt/ext/pihole/etc-pihole:/mnt/etc-pihole/
+		- /mnt/ext/pihole/etc-dnsmasq.d:/mnt/etc-dnsmasq.d/
     rest of pihole config...
-pihole-sync:
-    image: shirom/pihole-sync
-    container_name: pihole-sync
+
+pihole-sync-sender:
+    image: shirom/pihole-sync:latest
+    container_name: pihole-sync-sender
     volumes:
-        - ~/.ssh/id_rsa:/root/.ssh/id_rsa:ro
-        - /mnt/ext/pihole/etc-pihole:/mnt/pihole
-        - /mnt/ext/pihole/etc-dnsmasq.d:/mnt/dnsmasq.d
+        - /mnt/ext/piholesync/root:/root
+        - /mnt/ext/pihole/etc-pihole:/mnt/etc-pihole:ro
+        - /mnt/ext/pihole/etc-dnsmasq.d:/mnt/etc-dnsmasq.d:ro
     environment:
-        - CLIENTDIR="pi@192.168.0.16:/home/pi/pihole/pihole"
+        - "NODE=sender"
+        - "REM_HOST=(IP address of remote Pi)"
+        - "REM_SSH_PORT=22222"
 ```
+
+This is the `docker-compose.yml` for the sender/master Pi-Hole:
+
+```yaml
+pihole-sync-receiver:
+    image: shirom/pihole-sync:latest
+    container_name: pihole-sync-receiver
+    volumes:
+        - /mnt/ext/piholesync/root:/root
+        - /mnt/ext/piholesync/etc-ssh:/etc/ssh
+        - /mnt/ext/pihole/etc-pihole:/mnt/etc-pihole
+        - /mnt/ext/pihole/etc-dnsmasq.d:/mnt/etc-dnsmasq.d
+    environment:
+        - "NODE=receiver"
+    ports:
+        - 22222:22
+```
+
 ### Volumes
 Volume | Function 
 --- | -------- 
-`/root/.ssh/id_rsa:ro` | If your client directory is on a remote computer, you need the ssh keys to access it without a password. This directory stores them. Your keys are in ~/.ssh by default. See [this](https://www.tecmint.com/ssh-passwordless-login-using-ssh-keygen-in-5-easy-steps/) for a tutorial on SSH without a password. You should mount they key specifically, and not the whole ~/.ssh directory. Also ensure that proper permissions are set on your key (At least 600, if not 400).
-`/mnt/pihole` | This is the `/etc/pihole/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/pihole/ in the Pihole Docker container. See the compose file for details.
-`/mnt/dnsmasq.d` | This is the `/etc/dnsmasq.d/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/dnsmasq.d/ in the Pihole Docker container. See the compose file for details.
+`/root` | This is the directory in which the SSH key file and the known hosts file will be stored, so it needs to be persistent.
+`/etc/ssh` | This is the directory in which the SSH server key files and the SSH daemon config will be stored, so it needs to be persistent. This directory is only necessary on the `receiver` node, you can omit it on the `sender` node.
+`/mnt/etc-pihole` | This is the `/etc/pihole/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/pihole/ in the Pihole Docker container. See the compose file for details. For sending purposes, it can be mounted as read-only. It should not be read-only on the receiver.
+`/mnt/etc-dnsmasq.d` | This is the `/etc/dnsmasq.d/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/dnsmasq.d/ in the Pihole Docker container. See the compose file for details. For sending purposes, it can be mounted as read-only. It should not be read-only on the receiver.
 
 ### Environment Variables
 Variable | Function
 --- | --------
-`PIHOLECLIENTDIR` | This is the directory on the host filesystem of the client that `/etc/pihole/` should be synced to.
-`DNSMASQCLIENTDIR` | This is the directory on the host filesystem of the client that the master `/etc/dnsmasq.d/` should be synced to.
+`NODE` | This is where you should define if the container is the `sender` or the `receiver`. **Required on both nodes.**
+`REM_HOST` | This is the IP address (or FQDN/Hostname) of the remote Pi that we're syncting to. **Required on the `sender` node only.**
+`REM_SSH_PORT` | This is the non-standard SSH port that should be exposed on the container. Default of 22222 is probably fine. However, if you change this on the `sender` node, be sure to change the exposed port forward on the `receiver` node. **Required on the `sender` node only.**
 
-Assuming the above directories are on a remote host, make sure that the client can be SSHed into without a password. See [this](https://www.tecmint.com/ssh-passwordless-login-using-ssh-keygen-in-5-easy-steps/) for a tutorial on SSH without a password. 
+### Ports
+Port | Function
+--- | --------
+`22222` | This is the port you want to expose for rsync/ssh. Your host is likely using 22 for SSH already, so it should be a non-standard port. The default of 22222 is probably fine. However, if you change this on the `receiver` node, be sure to change the `REM_SSH_PORT` on the `sender` node. **Required on the `receiver` node only.**
 
 ## Support Information
 - Shell access while the container is running: `docker exec -it pihole-sync /bin/bash`

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pihole:
     image: pihole/pihole:latest
     volumes:
         - /mnt/ext/pihole/etc-pihole:/etc/pihole
-        - /mnt/ext/pihole/etc-dnsmasq-d:/etc/dnsmasq.d
+        - /mnt/ext/pihole/etc-dnsmasq.d:/etc/dnsmasq.d
     rest of pihole config...
 
 pihole-sync-sender:
@@ -63,7 +63,7 @@ pihole:
     image: pihole/pihole:latest
     volumes:
         - /mnt/ext/pihole/etc-pihole:/etc/pihole
-        - /mnt/ext/pihole/etc-dnsmasq-d:/etc/dnsmasq.d
+        - /mnt/ext/pihole/etc-dnsmasq.d:/etc/dnsmasq.d
     rest of pihole config...
 
 pihole-sync-receiver:

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ pihole-sync-receiver:
 ### Volumes
 Volume | Function 
 --- | -------- 
-`/root` | This is the directory in which the SSH key file and the known hosts file will be stored, so it needs to be persistent.<br />**Required on both nodes.**
-`/etc/ssh` | This is the directory in which the SSH server key files and the SSH daemon config will be stored, so it needs to be persistent.<br />**Required on the `sender` node only.**
-`/mnt/etc-pihole` | This is the `/etc/pihole/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/pihole/ in the Pihole Docker container. See the compose file for details.<br />**Required on both nodes. Can be mounted read-only on the `sender` node.**
-`/mnt/etc-dnsmasq.d` | This is the `/etc/dnsmasq.d/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/dnsmasq.d/ in the Pihole Docker container. See the compose file for details.<br />**Required on both nodes. Can be mounted read-only on the `sender` node.**
+`/mnt/ext/piholesync/root` | This is the directory in which the SSH key file and the known hosts file will be stored, so it needs to be persistent.<br />**Required on both nodes.**
+`/mnt/ext/piholesync/etc-ssh` | This is the directory in which the SSH server key files and the SSH daemon config will be stored, so it needs to be persistent. Can be a volume rather than a bind path, if you prefer.<br />**Required on the `sender` node only.**
+`/mnt/ext/pihole/etc-pihole` | This is the `/etc/pihole/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/pihole/ in the Pihole Docker container. See the compose file for details.<br />**Required on both nodes. Can be mounted read-only on the `sender` node.**
+`/mnt/ext/pihole/etc-dnsmasq.d` | This is the `/etc/dnsmasq.d/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/dnsmasq.d/ in the Pihole Docker container. See the compose file for details.<br />**Required on both nodes. Can be mounted read-only on the `sender` node.**
 
 ### Environment Variables
 Variable | Function

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Because Pi-Hole Docker utilizes a UID/GID of 0:0 and 999:999, this presents a un
 
 By utilizing a `sender` container node on one Pi and a `receiver` container node on the other Pi, we're able to solve the issue of securely opening a root user to SSH, by having the `sender` container node SSH into the `receiver` container node, rather than the host. If the container were to be infiltrated, the infiltrater would have access to root only in the receiver container, and its mounted volumes.
 
+**NOTE**: The sending and recieving container are only necessary for solving permissions issues without giving root access to the recieving container. If you have no problem giving root access to the recieving end (at the cost of security), or your recieving Pihole is not running in Docker, you don't need to use the recieving container. 
+
 ## Why Docker PiHole Sync
 
 There are other options out there such as [pihole-cloudsync](https://github.com/stevejenkins/pihole-cloudsync) and [pihole-sync](https://github.com/simonwhitaker/pihole-sync), but this repo offers 4 unique features:
@@ -27,8 +29,7 @@ Not only are your lists transferred, but all your other settings are transferred
 ### 4. Keeps Your Github Clean
 Unlike [pihole-cloudsync](https://github.com/stevejenkins/pihole-cloudsync), we don't require a repository to sync to. This means that your Piholes don't have to connect to the internet, and you don't have a large number of commits going into a dummy repository. This is especially nice if you show private contributions on your profile and don't want a huge number of changes being published to your Github profile
 
-#### NOTE: 
-The 'sender' Pihole must be able to SSH into the 'receiver' Pihole. If that's a restriction (maybe your Piholes are behind different VPNs), use [pihole-cloudsync](https://github.com/stevejenkins/pihole-cloudsync). 
+**NOTE**: The 'sender' Pihole must be able to SSH into the 'receiver' Pihole. If that's a restriction (maybe your Piholes are behind different VPNs), use [pihole-cloudsync](https://github.com/stevejenkins/pihole-cloudsync). 
 
 ## Setup
 ### docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -76,22 +76,22 @@ pihole-sync-receiver:
 ### Volumes
 Volume | Function 
 --- | -------- 
-`/root` | This is the directory in which the SSH key file and the known hosts file will be stored, so it needs to be persistent.  **Required on both nodes.**
-`/etc/ssh` | This is the directory in which the SSH server key files and the SSH daemon config will be stored, so it needs to be persistent.  **Required on the `sender` node only.**
-`/mnt/etc-pihole` | This is the `/etc/pihole/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/pihole/ in the Pihole Docker container. See the compose file for details.  **Required on both nodes. Can be mounted read-only on the `sender` node.**
-`/mnt/etc-dnsmasq.d` | This is the `/etc/dnsmasq.d/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/dnsmasq.d/ in the Pihole Docker container. See the compose file for details.  **Required on both nodes. Can be mounted read-only on the `sender` node.**
+`/root` | This is the directory in which the SSH key file and the known hosts file will be stored, so it needs to be persistent.<br />**Required on both nodes.**
+`/etc/ssh` | This is the directory in which the SSH server key files and the SSH daemon config will be stored, so it needs to be persistent.<br />**Required on the `sender` node only.**
+`/mnt/etc-pihole` | This is the `/etc/pihole/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/pihole/ in the Pihole Docker container. See the compose file for details.<br />**Required on both nodes. Can be mounted read-only on the `sender` node.**
+`/mnt/etc-dnsmasq.d` | This is the `/etc/dnsmasq.d/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/dnsmasq.d/ in the Pihole Docker container. See the compose file for details.<br />**Required on both nodes. Can be mounted read-only on the `sender` node.**
 
 ### Environment Variables
 Variable | Function
 --- | --------
-`NODE` | This is where you should define if the container is the `sender` or the `receiver`.  **Required on both nodes.**
-`REM_HOST` | This is the IP address (or FQDN/Hostname) of the remote Pi that we're syncting to.  **Required on the `sender` node only.**
-`REM_SSH_PORT` | This is the non-standard SSH port that should be exposed on the container. Default of 22222 is probably fine. However, if you change this on the `sender` node, be sure to change the exposed port forward on the `receiver` node.  **Required on the `sender` node only.**
+`NODE` | This is where you should define if the container is the `sender` or the `receiver`.<br />**Required on both nodes.**
+`REM_HOST` | This is the IP address (or FQDN/Hostname) of the remote Pi that we're syncting to.<br />**Required on the `sender` node only.**
+`REM_SSH_PORT` | This is the non-standard SSH port that should be exposed on the container. Default of 22222 is probably fine. However, if you change this on the `sender` node, be sure to change the exposed port forward on the `receiver` node.<br />**Required on the `sender` node only.**
 
 ### Ports
 Port | Function
 --- | --------
-`22222` | This is the port you want to expose for rsync/ssh. Your host is likely using 22 for SSH already, so it should be a non-standard port. The default of 22222 is probably fine. However, if you change this on the `receiver` node, be sure to change the `REM_SSH_PORT` on the `sender` node.  **Required on the `receiver` node only.**
+`22222` | This is the port you want to expose for rsync/ssh. Your host is likely using 22 for SSH already, so it should be a non-standard port. The default of 22222 is probably fine. However, if you change this on the `receiver` node, be sure to change the `REM_SSH_PORT` on the `sender` node.<br />**Required on the `receiver` node only.**
 
 ## Support Information
 - Shell access while the container is running: `docker exec -it pihole-sync /bin/bash`

--- a/README.md
+++ b/README.md
@@ -76,30 +76,22 @@ pihole-sync-receiver:
 ### Volumes
 Volume | Function 
 --- | -------- 
-`/root` | This is the directory in which the SSH key file and the known hosts file will be stored, so it needs to be persistent.
-**Required on both nodes.**
-`/etc/ssh` | This is the directory in which the SSH server key files and the SSH daemon config will be stored, so it needs to be persistent. 
-**Required on the `sender` node only.**
-`/mnt/etc-pihole` | This is the `/etc/pihole/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/pihole/ in the Pihole Docker container. See the compose file for details. 
-**Required on both nodes. Can be mounted read-only on the `sender` node.**
-`/mnt/etc-dnsmasq.d` | This is the `/etc/dnsmasq.d/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/dnsmasq.d/ in the Pihole Docker container. See the compose file for details.
-**Required on both nodes. Can be mounted read-only on the `sender` node.**
+`/root` | This is the directory in which the SSH key file and the known hosts file will be stored, so it needs to be persistent.  **Required on both nodes.**
+`/etc/ssh` | This is the directory in which the SSH server key files and the SSH daemon config will be stored, so it needs to be persistent.  **Required on the `sender` node only.**
+`/mnt/etc-pihole` | This is the `/etc/pihole/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/pihole/ in the Pihole Docker container. See the compose file for details.  **Required on both nodes. Can be mounted read-only on the `sender` node.**
+`/mnt/etc-dnsmasq.d` | This is the `/etc/dnsmasq.d/` directory the Pi-Hole container writes to on the host filesystem. It is monitored and sychronized with the remote client directory. It should be set to the same as the /etc/dnsmasq.d/ in the Pihole Docker container. See the compose file for details.  **Required on both nodes. Can be mounted read-only on the `sender` node.**
 
 ### Environment Variables
 Variable | Function
 --- | --------
-`NODE` | This is where you should define if the container is the `sender` or the `receiver`.
-**Required on both nodes.**
-`REM_HOST` | This is the IP address (or FQDN/Hostname) of the remote Pi that we're syncting to.
-**Required on the `sender` node only.**
-`REM_SSH_PORT` | This is the non-standard SSH port that should be exposed on the container. Default of 22222 is probably fine. However, if you change this on the `sender` node, be sure to change the exposed port forward on the `receiver` node.
-**Required on the `sender` node only.**
+`NODE` | This is where you should define if the container is the `sender` or the `receiver`.  **Required on both nodes.**
+`REM_HOST` | This is the IP address (or FQDN/Hostname) of the remote Pi that we're syncting to.  **Required on the `sender` node only.**
+`REM_SSH_PORT` | This is the non-standard SSH port that should be exposed on the container. Default of 22222 is probably fine. However, if you change this on the `sender` node, be sure to change the exposed port forward on the `receiver` node.  **Required on the `sender` node only.**
 
 ### Ports
 Port | Function
 --- | --------
-`22222` | This is the port you want to expose for rsync/ssh. Your host is likely using 22 for SSH already, so it should be a non-standard port. The default of 22222 is probably fine. However, if you change this on the `receiver` node, be sure to change the `REM_SSH_PORT` on the `sender` node.
-**Required on the `receiver` node only.**
+`22222` | This is the port you want to expose for rsync/ssh. Your host is likely using 22 for SSH already, so it should be a non-standard port. The default of 22222 is probably fine. However, if you change this on the `receiver` node, be sure to change the `REM_SSH_PORT` on the `sender` node.  **Required on the `receiver` node only.**
 
 ## Support Information
 - Shell access while the container is running: `docker exec -it pihole-sync /bin/bash`

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ pihole-sync-sender:
 This is the `docker-compose.yml` for the receiver/secondary Pi-Hole:
 
 ```yaml
+pihole:
+    image: pihole/pihole:latest
+    volumes:
+        - /mnt/ext/pihole/etc-pihole:/mnt/etc-pihole
+        - /mnt/ext/pihole/etc-dnsmasq-d:/mnt/etc-dnsmasq.d
+    rest of pihole config...
+
 pihole-sync-receiver:
     image: shirom/pihole-sync:latest
     container_name: pihole-sync-receiver

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pihole-sync-sender:
         - "REM_SSH_PORT=22222"
 ```
 
-This is the `docker-compose.yml` for the sender/master Pi-Hole:
+This is the `docker-compose.yml` for the receiver/secondary Pi-Hole:
 
 ```yaml
 pihole-sync-receiver:

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ This is the `docker-compose.yml` for the sender/master Pi-Hole:
 pihole:
     image: pihole/pihole:latest
     volumes:
-        - /mnt/ext/pihole/etc-pihole:/mnt/etc-pihole/
-		- /mnt/ext/pihole/etc-dnsmasq.d:/mnt/etc-dnsmasq.d/
+        - /mnt/ext/pihole/etc-pihole:/mnt/etc-pihole
+        - /mnt/ext/pihole/etc-dnsmasq-d:/mnt/etc-dnsmasq.d
     rest of pihole config...
 
 pihole-sync-sender:

--- a/entryPoint.sh
+++ b/entryPoint.sh
@@ -59,12 +59,12 @@ if [[ "${NODE,,}" == "sender" ]]; then
             exit 3
         fi
     fi
-    rsync -a -P --exclude '01-pihole.conf' /mnt/etc-dnsmasq.d/ -e "ssh -p ${REM_SSH_PORT}" ${REM_USER}@${REM_HOST}:/mnt/etc-dnsmasq.d/ --delete
+    rsync -a -P --exclude '01-pihole.conf' /mnt/etc-dnsmasq.d/ -e "ssh -p ${REM_SSH_PORT}" root@${REM_HOST}:/mnt/etc-dnsmasq.d/ --delete
     if [[ "${?}" -ne "0" ]]; then
         echo "Unable to initiate dnsmasq.d rsync. Is the receiver online?"
         exit 4
     fi
-    rsync -a -P --exclude 'localbranches' --exclude 'localversions' --exclude 'setupVars.conf' --exclude 'setupVars.conf.update.bak' --exclude 'pihole-FTL.db' -e "ssh -p ${REM_SSH_PORT}" /mnt/etc-pihole/ ${REM_USER}@${REM_HOST}:/mnt/etc-pihole/ --delete
+    rsync -a -P --exclude 'localbranches' --exclude 'localversions' --exclude 'setupVars.conf' --exclude 'setupVars.conf.update.bak' --exclude 'pihole-FTL.db' -e "ssh -p ${REM_SSH_PORT}" /mnt/etc-pihole/ root@${REM_HOST}:/mnt/etc-pihole/ --delete
     if [[ "${?}" -ne "0" ]]; then
         echo "Unable to initiate dnsmasq.d rsync. Is the receiver online?"
         exit 5

--- a/entryPoint.sh
+++ b/entryPoint.sh
@@ -1,9 +1,100 @@
 #!/bin/bash
-chmod +x /sync-dnsmasq.sh /sync-pihole.sh
-hostOnly="${PIHOLECLIENTDIR#*@}"
-hostOnly="${hostOnly%%:*}"
-ssh-keyscan -H ${hostOnly} > /root/.ssh/known_hosts 2>/dev/null
-bash -c "rsync -aP --exclude '01-pihole.conf' /mnt/dnsmasq/ ${DNSMASQCLIENTDIR} --delete"
-bash -c "rsync -aP --exclude 'pihole-FTL.db' /mnt/pihole/ ${PIHOLECLIENTDIR} --delete"
-( /sync-dnsmasq.sh ) &
-/sync-pihole.sh
+
+fail="1"
+if [[ -z "${NODE,,}" ]]; then
+    fail="0"
+elif [[ "${NODE,,}" == "sender" ]]; then
+    fail="0"
+elif [[ "${NODE,,}" == "receiver" ]]; then
+    fail="0"
+elif ! mount | grep -q "/mnt/etc-pihole"; then
+    echo "Please define a /mnt/etc-pihole config path."
+    echo "This should be a physical path, such as:"
+    echo "-v \"~/etc-pihole:/mnt/etc-pihole\""
+    fail="1"
+elif ! mount | grep -q "/mnt/etc-dnsmasq.d"; then
+    echo "Please define a /mnt/etc-dnsmasq.d config path."
+    echo "This should be a physical path, such as:"
+    echo "-v \"~/etc-dnsmasq.d:/mnt/etc-dnsmasq.d\""
+    fail="1"
+fi
+if [[ "${fail}" -eq "1" ]]; then
+    echo "Please set environmental flag 'NODE=[sender|receiver]'"
+    exit 1
+fi
+
+if [[ "${NODE,,}" == "sender" ]]; then
+    if ! mount | grep -q "/root"; then
+        echo "Please define a root config path."
+        echo "This should be a physical path, such as:"
+        echo "-v \"~/piholesync/root:/root\""
+        exit 2
+    fi
+    if ! [[ -e "/root/.ssh/id_ed25519" ]]; then
+        ssh-keygen -b 2048 -t ed25519 -f /root/.ssh/id_ed25519 -q -N ""
+        chmod 400 "/root/.ssh/id_ed25519"
+        echo ""
+        echo "On the receiver node, create an authorized_keys file in the config directory"
+        echo ""
+        echo "For example, if your 'config' volume mount on the receiver is:"
+        echo "-v /docker/config/piholesync/root:/root"
+        echo ""
+        echo "Then you would create a file at:"
+        echo "/docker/config/piholesync/root/.ssh/authorized_keys"
+        echo ""
+        echo "Copy/paste the contents between the ##### markers into that authorized_keys file:"
+        echo ""
+        echo "####### COPY BELOW THIS LINE, BUT NOT THIS LINE ########"
+        cat "/root/.ssh/id_ed25519.pub"
+        echo "####### COPY ABOVE THIS LINE, BUT NOT THIS LINE ########"
+        echo ""
+        echo "Once done, re-start this conatiner."
+        exit 0
+    fi
+    if ! [[ -e "/root/.ssh/known_hosts" ]]; then
+        ssh-keyscan -p ${REM_SSH_PORT} ${REM_HOST} > /root/.ssh/known_hosts 2>/dev/null
+        if [[ "${?}" -ne "0" || "$(wc -l "/root/.ssh/known_hosts" | awk '{print $1}')" -eq "0" ]]; then
+            echo "Unable to initiate keyscan. Is the receiver online?"
+            rm "/root/.ssh/known_hosts"
+            exit 3
+        fi
+    fi
+    rsync -a -P --exclude '01-pihole.conf' /mnt/etc-dnsmasq.d/ -e "ssh -p ${REM_SSH_PORT}" ${REM_USER}@${REM_HOST}:/mnt/etc-dnsmasq.d/ --delete
+    rsync -a -P --exclude 'setupVars.conf' --exclude 'setupVars.conf.update.bak' --exclude 'pihole-FTL.db' -e "ssh -p ${REM_SSH_PORT}" /mnt/etc-pihole/ ${REM_USER}@${REM_HOST}:/mnt/etc-pihole/ --delete
+    chmod +x /sync-dnsmasq.sh /sync-pihole.sh
+    ( /sync-dnsmasq.sh ) &
+    /sync-pihole.sh
+fi
+
+if [[ "${NODE,,}" == "receiver" ]]; then
+    if ! mount | grep -q "/etc/ssh"; then
+        echo "Please define an /etc/ssh config path."
+        echo "This should be a physical path, such as:"
+        echo "-v \"~/piholesync/etc-ssh:/etc/ssh\""
+        exit 3
+    fi
+    if ! mount | grep -q "/root"; then
+        echo "Please define a root config path."
+        echo "This should be a physical path, such as:"
+        echo "-v \"~/piholesync/root:/root\""
+        exit 4
+    fi
+    if ! [[ -e "/root/.ssh/authorized_keys" ]]; then
+        echo "Please obtain the 'authorized_keys' file from the sender,"
+        echo "and add it at your root/.ssh/authorized_keys path"
+        exit 5
+    fi
+    sshKeyArr=("ssh_host_dsa_key" "ssh_host_dsa_key.pub" "ssh_host_ecdsa_key" "ssh_host_ecdsa_key.pub" "ssh_host_ed25519_key" "ssh_host_ed25519_key.pub" "ssh_host_rsa_key" "ssh_host_rsa_key.pub")
+    for i in "${sshKeyArr[@]}"; do
+        if ! [[ -e "/etc/ssh/${i}" ]]; then
+            ssh-keygen -A
+        fi
+    done
+    mv /sshd_config /etc/ssh/sshd_config
+    rootPass="$(date +%s | sha256sum | base64 | head -c 36)"
+    echo "root:${rootPass}" | chpasswd
+    chmod 700 /root
+    chmod 700 /root/.ssh
+    chmod 600 /root/.ssh/authorized_keys
+    /usr/sbin/sshd -D -e
+fi

--- a/healthCheck.sh
+++ b/healthCheck.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
-if [[ -e "/fail" ]]; then
-  exit 1
+if [[ "${NODE,,}" == "sender" ]]; then
+    if [[ -e "/fail" ]]; then
+        exit 1
+    fi
+elif [[ "${NODE,,}" == "receiver" ]]; then
+    netstat -plant | grep -q :22
+    if [[ "${?}" -ne "0" ]]; then
+        exit 2
+    fi
 fi

--- a/sshd_config
+++ b/sshd_config
@@ -1,0 +1,27 @@
+Port 22
+AddressFamily any
+ListenAddress 0.0.0.0
+ListenAddress ::
+SyslogFacility AUTH
+LogLevel INFO
+LoginGraceTime 30s
+PermitRootLogin yes
+StrictModes yes
+MaxAuthTries 2
+MaxSessions 4
+PubkeyAuthentication yes
+AuthorizedKeysFile .ssh/authorized_keys
+PasswordAuthentication no
+PermitEmptyPasswords no
+ChallengeResponseAuthentication no
+AllowAgentForwarding yes
+AllowTcpForwarding yes
+GatewayPorts clientspecified
+X11Forwarding no
+PermitTTY yes
+PrintMotd no
+TCPKeepAlive yes
+PermitUserEnvironment no
+Compression delayed
+MaxStartups 10:20:30
+Subsystem sftp /usr/lib/openssh/sftp-server

--- a/sync-dnsmasq.sh
+++ b/sync-dnsmasq.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 inotifywait -r -m -e close_write --exclude '01-pihole\.conf' --format '%w%f' /mnt/etc-dnsmasq.d/ | while read MODFILE
 do
-    rsync -a -P --exclude '01-pihole.conf' /mnt/etc-dnsmasq.d/ -e "ssh -p ${REM_SSH_PORT}" ${REM_USER}@${REM_HOST}:/mnt/etc-dnsmasq.d/ --delete
+    rsync -a -P --exclude '01-pihole.conf' /mnt/etc-dnsmasq.d/ -e "ssh -p ${REM_SSH_PORT}" root@${REM_HOST}:/mnt/etc-dnsmasq.d/ --delete
     if [[ "${?}" -ne "0" ]]; then
         touch /fail
     fi

--- a/sync-dnsmasq.sh
+++ b/sync-dnsmasq.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-inotifywait -r -m -e close_write --exclude '01-pihole.conf' --format '%w%f' /mnt/dnsmasq | while read MODFILE
+inotifywait -r -m -e close_write --exclude '01-pihole\.conf' --format '%w%f' /mnt/etc-dnsmasq.d/ | while read MODFILE
 do
-    bash -c "rsync -aP --exclude '01-pihole.conf' /mnt/dnsmasq/ ${DNSMASQCLIENTDIR} --delete"
+    rsync -a -P --exclude '01-pihole.conf' /mnt/etc-dnsmasq.d/ -e "ssh -p ${REM_SSH_PORT}" ${REM_USER}@${REM_HOST}:/mnt/etc-dnsmasq.d/ --delete
     if [[ "${?}" -ne "0" ]]; then
         touch /fail
     fi

--- a/sync-pihole.sh
+++ b/sync-pihole.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 inotifywait -r -m -e close_write --exclude '((setupVars|setupVars|pihole-FTL)\.(conf|conf\.update\.bak|db)|local(branche|version)s)' --format '%w%f' /mnt/etc-pihole/ | while read MODFILE
 do
-    rsync -a -P --exclude 'setupVars.conf' --exclude 'setupVars.conf.update.bak' --exclude 'pihole-FTL.db' -e "ssh -p ${REM_SSH_PORT}" /mnt/etc-pihole/ ${REM_USER}@${REM_HOST}:/mnt/etc-pihole/ --delete
+    rsync -a -P --exclude 'setupVars.conf' --exclude 'setupVars.conf.update.bak' --exclude 'pihole-FTL.db' -e "ssh -p ${REM_SSH_PORT}" /mnt/etc-pihole/ root@${REM_HOST}:/mnt/etc-pihole/ --delete
     if [[ "${?}" -ne "0" ]]; then
         touch /fail
     fi

--- a/sync-pihole.sh
+++ b/sync-pihole.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-inotifywait -r -m -e close_write --format '%w%f' /mnt/pihole | while read MODFILE
+inotifywait -r -m -e close_write --exclude '((setupVars|setupVars|pihole-FTL)\.(conf|conf\.update\.bak|db)|local(branche|version)s)' --format '%w%f' /mnt/etc-pihole/ | while read MODFILE
 do
-    bash -c "rsync -aP --exclude 'pihole-FTL.db' /mnt/pihole/ ${PIHOLECLIENTDIR} --delete"
+    rsync -a -P --exclude 'setupVars.conf' --exclude 'setupVars.conf.update.bak' --exclude 'pihole-FTL.db' -e "ssh -p ${REM_SSH_PORT}" /mnt/etc-pihole/ ${REM_USER}@${REM_HOST}:/mnt/etc-pihole/ --delete
     if [[ "${?}" -ne "0" ]]; then
         touch /fail
     fi


### PR DESCRIPTION
I slimmed the image down by switching it from Debian to Alpine

I re-configured it so that you now much run a container on both the sender, and the receiver, but the trade off is that there is now a containerized root user which you can send to, which allows for preservation of the UID/GID of files, until Pi-Hole modifies their docker containers to allow running as non-root.