### PR TITLE
Enable ARM64 and ARMv6, fix healthCheck

### DIFF
--- a/.github/workflows/dockerhub-push.yml
+++ b/.github/workflows/dockerhub-push.yml
@@ -35,6 +35,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
           push: true
           tags: shirom/pihole-sync:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3
 
 RUN apk -U update
 RUN apk add --no-cache dumb-init openssh-client openssh-server rsync inotify-tools bind-tools bash

--- a/sync-dnsmasq.sh
+++ b/sync-dnsmasq.sh
@@ -4,5 +4,7 @@ do
     rsync -a -P --exclude '01-pihole.conf' /mnt/etc-dnsmasq.d/ -e "ssh -p ${REM_SSH_PORT}" root@${REM_HOST}:/mnt/etc-dnsmasq.d/ --delete
     if [[ "${?}" -ne "0" ]]; then
         touch /fail
+    elif [[ -f "/fail" ]]; then
+        rm -f /fail
     fi
 done

--- a/sync-pihole.sh
+++ b/sync-pihole.sh
@@ -4,5 +4,7 @@ do
     rsync -a -P --exclude 'setupVars.conf' --exclude 'setupVars.conf.update.bak' --exclude 'pihole-FTL.db' -e "ssh -p ${REM_SSH_PORT}" /mnt/etc-pihole/ root@${REM_HOST}:/mnt/etc-pihole/ --delete
     if [[ "${?}" -ne "0" ]]; then
         touch /fail
+    elif [[ -f "/fail" ]]; then
+	rm -f /fail
     fi
 done


### PR DESCRIPTION
Enable building of ARM64 and ARMv6 images in GH Actions.
Should fix #9 and #7.

Also fixes the healthCheck getting stuck on unhealthy when a single sync fails but subsequent syncs are successful.