### PR TITLE
dhcp.leases Shouldn't be Synced

### DIFF
--- a/sync-pihole.sh
+++ b/sync-pihole.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-inotifywait -r -m -e close_write --exclude '((setupVars|setupVars|pihole-FTL)\.(conf|conf\.update\.bak|db)|local(branche|version)s)' --format '%w%f' /mnt/etc-pihole/ | while read MODFILE
+inotifywait -r -m -e close_write --exclude '((setupVars|setupVars|pihole-FTL)\.(conf|conf\.update\.bak|db)|local(branche|version)s|dhcp\.leases)' --format '%w%f' /mnt/etc-pihole/ | while read MODFILE
 do
-    rsync -a -P --exclude 'setupVars.conf' --exclude 'setupVars.conf.update.bak' --exclude 'pihole-FTL.db' -e "ssh -p ${REM_SSH_PORT}" /mnt/etc-pihole/ root@${REM_HOST}:/mnt/etc-pihole/ --delete
+    rsync -a -P --exclude 'dhcp.leases' --exclude 'setupVars.conf' --exclude 'setupVars.conf.update.bak' --exclude 'pihole-FTL.db' -e "ssh -p ${REM_SSH_PORT}" /mnt/etc-pihole/ root@${REM_HOST}:/mnt/etc-pihole/ --delete
     if [[ "${?}" -ne "0" ]]; then
         touch /fail
     elif [[ -f "/fail" ]]; then


### PR DESCRIPTION
dhcp.leases is the file containing the DHCP leases. Since the Pi-holes don't know about eachother's leases, they need to be able to write to their respective lease files separately. Currently, the second hosts' leases are just forgotten as soon as they are created.