### PR TITLE
Readme.md correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,17 @@ Port | Function
 - Shell access while the container is running: `docker exec -it pihole-sync /bin/bash`
 - Logs: `docker logs pihole-sync`
 - Note the SSH-key instructions:
-
+    
+    **Receiver node**
+    
     On the receiver node, create an authorized_keys file in the config directory
     For example, if your 'config' volume mount on the receiver is:
         /docker/config/piholesync/root:/root"
 
     Then you would create a file at:
         /docker/config/piholesync/root/.ssh/authorized_keys"
+    
+    **Sender node**
     
     The SSH-key instructions are given in the log of the sender, these are only given once.
     

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Port | Function
 
     Then you would create a file at:
         /docker/config/piholesync/root/.ssh/authorized_keys"
-
+    
+    The SSH-key instructions are given in the log of the sender, these are only given once.
     Copy/paste the contents between the ##### markers into that authorized_keys file:"
 
         ####### COPY BELOW THIS LINE, BUT NOT THIS LINE ########"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Port | Function
         /docker/config/piholesync/root/.ssh/authorized_keys"
     
     The SSH-key instructions are given in the log of the sender, these are only given once.
+    
     Copy/paste the contents between the ##### markers into that authorized_keys file:"
 
         ####### COPY BELOW THIS LINE, BUT NOT THIS LINE ########"


### PR DESCRIPTION
After the last update, it was missing where the "SSH-key instructions are given". 

This part is essential and should stay in!